### PR TITLE
주차계산 로직, 바텀시트 영역 외 터치 커스텀훅

### DIFF
--- a/src/components/common/bottomSheets/CommonSheet.tsx
+++ b/src/components/common/bottomSheets/CommonSheet.tsx
@@ -6,6 +6,7 @@ interface CommonSheetProps {
   open: boolean;
   onDismiss: () => void;
   blocking?: boolean;
+  sheetRef?: React.RefObject<HTMLDivElement>;
 }
 
 function CommonSheet({
@@ -13,6 +14,7 @@ function CommonSheet({
   open,
   onDismiss,
   blocking = true,
+  sheetRef,
 }: CommonSheetProps) {
   document.documentElement.style.setProperty(
     '--rsbs-backdrop-bg',
@@ -27,7 +29,9 @@ function CommonSheet({
       snapPoints={({ minHeight }) => minHeight}
       blocking={blocking}
     >
-      <SheetContainer>{children}</SheetContainer>
+      <div ref={sheetRef}>
+        <SheetContainer>{children}</SheetContainer>
+      </div>
     </StyledBottomSheet>
   );
 }

--- a/src/components/home/create/steps/Step3.tsx
+++ b/src/components/home/create/steps/Step3.tsx
@@ -15,6 +15,7 @@ import {
 import SheetButton from '@components/common/buttons/SheetButton';
 import getCommaThreeDigits from '@lib/utils/kid/getCommaThreeDigits';
 import InputForm from '@components/common/InputForm';
+import useBottomSheetOutSideRef from '@lib/hooks/useBottomSheetOutSideRef';
 
 type TStep3Form = {
   contractName: string;
@@ -33,8 +34,7 @@ function Step3({ currentStep }: { currentStep: number }) {
   const [validateAmount, checkValidateAmount] = useValidation();
   const [open, onOpen, onDismiss] = useBottomSheet(false);
   const [amountStack, pushAmount, popAmount, resetAmount] = useStackAmount();
-  const moneyRef = useRef<HTMLDivElement>(null);
-  const sheetRef = useRef<HTMLDivElement>(null);
+  const [sheetDivRef, inputDivRef] = useBottomSheetOutSideRef(onDismiss);
 
   //TODO : api fetching
   const testDuplicate = ['중복된 이름'];
@@ -45,24 +45,6 @@ function Step3({ currentStep }: { currentStep: number }) {
     navigate(`/create/${currentStep + 1}`, { state: { from: currentStep } });
   };
 
-  // 관련된 이외 부분 터치 시 바텀시트 내려가도록 이벤트 등록
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent): void => {
-      if (
-        sheetRef.current &&
-        moneyRef.current &&
-        !moneyRef.current.contains(e.target as Node) &&
-        !sheetRef.current.contains(e.target as Node)
-      ) {
-        onDismiss();
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [moneyRef, open]);
-
   // stack에 있는 숫자들 더해서 form state에 저장
   useEffect(() => {
     const amount = amountStack.reduce((acc, cur) => {
@@ -70,12 +52,6 @@ function Step3({ currentStep }: { currentStep: number }) {
     }, 0);
     setForm({ ...form, contractAmount: amount });
   }, [amountStack]);
-
-  // 첫 렌더링시에 스토어에 있는 값 가져와서 초기화??? (for 뒤로가기해서 온 경우)
-  // 코어타임때 물어보기
-  /*  useEffect(() => {
-    pushAmount(form.contractAmount);
-  }, []); */
 
   //form 값이 바뀔때마다 유효성검사 실행
   useEffect(() => {
@@ -109,7 +85,7 @@ function Step3({ currentStep }: { currentStep: number }) {
       </InputSection>
 
       <InputSection validate={validateAmount}>
-        <div onClick={onOpen} ref={moneyRef}>
+        <div onClick={onOpen} ref={inputDivRef}>
           <InputForm
             placeholder="부모님과 함께 모을 금액"
             value={
@@ -140,10 +116,10 @@ function Step3({ currentStep }: { currentStep: number }) {
         onDismiss={onDismiss}
         label={'다음'}
         onClickNext={onClickNextButton}
-        sheetRef={sheetRef}
+        sheetRef={sheetDivRef}
         disabledNext={disabledNext}
       >
-        <div ref={sheetRef}>
+        <div ref={sheetDivRef}>
           <SelectMoney
             pushAmount={pushAmount}
             popAmount={popAmount}

--- a/src/components/home/create/steps/Step4.tsx
+++ b/src/components/home/create/steps/Step4.tsx
@@ -23,6 +23,8 @@ import getChallengeStep4Weeks from '@lib/utils/kid/getChallengeStep4Weeks';
 import getCommaThreeDigits from '@lib/utils/kid/getCommaThreeDigits';
 import InputForm from '@components/common/InputForm';
 import useBottomSheetOutSideRef from '@lib/hooks/useBottomSheetOutSideRef';
+import moment from 'moment';
+import getWeekNumberByMonth from '@lib/utils/common/getWeekNumberByMonth';
 
 export type TStep4Form = {
   weekPrice: number;
@@ -98,9 +100,14 @@ function Step4({ currentStep }: { currentStep: number }) {
         form.weekPrice,
         form.interestRate,
       );
+      const endDate = moment()
+        .day(7)
+        .add(7 * weekCost, 'day');
+      const { month, weekNo } = getWeekNumberByMonth(endDate.toDate());
+      console.log(month, weekNo);
       setContractInfo({
         weekCost: weekCost,
-        contractEndWeek: '0월 0주', //TODO
+        contractEndWeek: `${month}월 ${weekNo}주`, //TODO
         overPrice: totalPriceWithInterest - totalPrice,
       });
     }

--- a/src/components/home/create/steps/Step4.tsx
+++ b/src/components/home/create/steps/Step4.tsx
@@ -22,6 +22,7 @@ import getChallengeStep4Prices from '@lib/utils/kid/getChallengeStep4Prices';
 import getChallengeStep4Weeks from '@lib/utils/kid/getChallengeStep4Weeks';
 import getCommaThreeDigits from '@lib/utils/kid/getCommaThreeDigits';
 import InputForm from '@components/common/InputForm';
+import useBottomSheetOutSideRef from '@lib/hooks/useBottomSheetOutSideRef';
 
 export type TStep4Form = {
   weekPrice: number;
@@ -51,19 +52,20 @@ function Step4({ currentStep }: { currentStep: number }) {
     overPrice: 0,
   });
   const [disabledNext, setDisabledNext] = useState<boolean>(true);
-  const weekPriceSheetRef = useRef<HTMLDivElement>(null);
-  const interestRateSheetRef = useRef<HTMLDivElement>(null);
-  const weekPriceInputRef = useRef<HTMLDivElement>(null);
-  const interestRateInputRef = useRef<HTMLDivElement>(null);
+  const [openWeekPrice, onOpenWeekPrice, onDismissWeekPrice] =
+    useBottomSheet(false);
+  const [openInterestRate, onOpenInterestRate, onDismissInterestRate] =
+    useBottomSheet(false);
+  const [weekPriceSheetDivRef, weekPriceInputDivRef] =
+    useBottomSheetOutSideRef(onDismissWeekPrice);
+  const [interestRateSheetDivRef, interestRateInputDivRef] =
+    useBottomSheetOutSideRef(onDismissInterestRate);
 
   const { minPrice, maxPrice, middlePrice } = getChallengeStep4Prices(
     totalPrice,
     form.interestRate,
   );
-  const [openWeekPrice, onOpenWeekPrice, onDismissWeekPrice] =
-    useBottomSheet(false);
-  const [openInterestRate, onOpenInterestRate, onDismissInterestRate] =
-    useBottomSheet(false);
+
   const { openModal } = useModals();
 
   // 모달 여는 함수
@@ -82,32 +84,6 @@ function Step4({ currentStep }: { currentStep: number }) {
     dispatch(dispatchWeeks(contractInfo.weekCost));
     navigate(`/create/${currentStep + 1}`, { state: { from: currentStep } });
   };
-
-  // 관련된 이외 부분 터치 시 바텀시트 내려가도록 이벤트 등록
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent): void => {
-      if (
-        weekPriceSheetRef.current &&
-        weekPriceInputRef.current &&
-        !weekPriceSheetRef.current.contains(e.target as Node) &&
-        !weekPriceInputRef.current.contains(e.target as Node)
-      ) {
-        onDismissWeekPrice();
-      }
-      if (
-        interestRateSheetRef.current &&
-        interestRateInputRef.current &&
-        !interestRateSheetRef.current.contains(e.target as Node) &&
-        !interestRateInputRef.current.contains(e.target as Node)
-      ) {
-        onDismissInterestRate();
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [weekPriceInputRef, interestRateInputRef]);
 
   // 다음으로 버튼 활성화,비활성화 처리
   useEffect(() => {
@@ -144,7 +120,7 @@ function Step4({ currentStep }: { currentStep: number }) {
             <Alert />
           </span>
         </p>
-        <div onClick={onOpenInterestRate} ref={interestRateInputRef}>
+        <div onClick={onOpenInterestRate} ref={interestRateInputDivRef}>
           <InputForm
             placeholder={getCommaThreeDigits(totalPrice * 0.2) + ' 원'}
             value={
@@ -168,7 +144,7 @@ function Step4({ currentStep }: { currentStep: number }) {
           onClick={() => {
             form.interestRate ? onOpenWeekPrice() : null;
           }}
-          ref={weekPriceInputRef}
+          ref={weekPriceInputDivRef}
         >
           <InputForm
             placeholder={getCommaThreeDigits(middlePrice) + ' 원'}
@@ -215,10 +191,10 @@ function Step4({ currentStep }: { currentStep: number }) {
         onDismiss={onDismissInterestRate}
         label={'다음'}
         onClickNext={onClickNextButton}
-        sheetRef={interestRateSheetRef}
+        sheetRef={interestRateSheetDivRef}
         disabledNext={disabledNext}
       >
-        <div ref={interestRateSheetRef}>
+        <div ref={interestRateSheetDivRef}>
           <SelectInterest form={form} setForm={setForm} />
         </div>
       </ContractSheet>
@@ -227,10 +203,10 @@ function Step4({ currentStep }: { currentStep: number }) {
         onDismiss={onDismissWeekPrice}
         label={'다음'}
         onClickNext={onClickNextButton}
-        sheetRef={weekPriceSheetRef}
+        sheetRef={weekPriceSheetDivRef}
         disabledNext={disabledNext}
       >
-        <div ref={weekPriceSheetRef}>
+        <div ref={weekPriceSheetDivRef}>
           <RangeInput
             totalPrice={totalPrice}
             min={minPrice}

--- a/src/components/register/RegisterRole.tsx
+++ b/src/components/register/RegisterRole.tsx
@@ -12,6 +12,7 @@ import { modals } from '../common/modals/Modals';
 import Modals from '../common/modals/Modals';
 import { useState } from 'react';
 import { TFetchStatus } from '@lib/types/api';
+import useBottomSheetOutSideRef from '@lib/hooks/useBottomSheetOutSideRef';
 
 function RegisterRole() {
   const dispatch = useAppDispatch();
@@ -21,26 +22,35 @@ function RegisterRole() {
   const birthday = useAppSelector(selectBirthday);
 
   const [open, onOpen, onDismiss] = useBottomSheet(false);
+  const [sheetDivRef, inputDivRef] = useBottomSheetOutSideRef(onDismiss);
 
   function handleDadButtonClick() {
-    setIsKid(false);
-    setIsFemale(false);
-    onOpen();
+    if (!open) {
+      setIsKid(false);
+      setIsFemale(false);
+      onOpen();
+    }
   }
   function handleMomButtonClick() {
-    setIsKid(false);
-    setIsFemale(true);
-    onOpen();
+    if (!open) {
+      setIsKid(false);
+      setIsFemale(true);
+      onOpen();
+    }
   }
   function handleSonButtonClick() {
-    setIsKid(true);
-    setIsFemale(false);
-    onOpen();
+    if (!open) {
+      setIsKid(true);
+      setIsFemale(false);
+      onOpen();
+    }
   }
   function handleDaughterButtonClick() {
-    setIsKid(true);
-    setIsFemale(true);
-    onOpen();
+    if (!open) {
+      setIsKid(true);
+      setIsFemale(true);
+      onOpen();
+    }
   }
 
   const { openModal } = useModals();
@@ -117,7 +127,8 @@ function RegisterRole() {
           isSelected={isKid === true && isFemale === true}
         />
       </div>
-      <CommonSheet open={open} onDismiss={onDismiss}>
+      <div ref={inputDivRef}></div>
+      <CommonSheet open={open} onDismiss={onDismiss} sheetRef={sheetDivRef}>
         <SelectProfile
           isKid={isKid}
           isFemale={isFemale}

--- a/src/lib/hooks/useBottomSheetOutSideRef.tsx
+++ b/src/lib/hooks/useBottomSheetOutSideRef.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+function useBottomSheetOutSideRef(handler: () => void) {
+  const sheetDivRef = useRef<HTMLDivElement>(null);
+  const inputDivRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent): void => {
+      if (
+        sheetDivRef.current &&
+        inputDivRef.current &&
+        !inputDivRef.current.contains(e.target as Node) &&
+        !sheetDivRef.current.contains(e.target as Node)
+      ) {
+        console.log('dismiss');
+        handler();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [inputDivRef]);
+
+  return [sheetDivRef, inputDivRef];
+}
+
+export default useBottomSheetOutSideRef;

--- a/src/lib/utils/common/getWeekNumberByMonth.ts
+++ b/src/lib/utils/common/getWeekNumberByMonth.ts
@@ -1,0 +1,69 @@
+function getWeekNumberByMonth(dateFormat: Date) {
+  const inputDate = new Date(dateFormat);
+
+  // 인풋의 년, 월
+  let year = inputDate.getFullYear();
+  let month = inputDate.getMonth() + 1;
+
+  // 목요일 기준 주차 구하기
+  const weekNumberByThurFnc = (paramDate: Date) => {
+    const year = paramDate.getFullYear();
+    const month = paramDate.getMonth();
+    const date = paramDate.getDate();
+
+    // 인풋한 달의 첫 날과 마지막 날의 요일
+    const firstDate = new Date(year, month, 1);
+    const lastDate = new Date(year, month + 1, 0);
+    const firstDayOfWeek = firstDate.getDay() === 0 ? 7 : firstDate.getDay();
+    const lastDayOfweek = lastDate.getDay();
+
+    // 인풋한 달의 마지막 일
+    const lastDay = lastDate.getDate();
+
+    // 첫 날의 요일이 금, 토, 일요일 이라면 true
+    const firstWeekCheck =
+      firstDayOfWeek === 5 || firstDayOfWeek === 6 || firstDayOfWeek === 7;
+    // 마지막 날의 요일이 월, 화, 수라면 true
+    const lastWeekCheck =
+      lastDayOfweek === 1 || lastDayOfweek === 2 || lastDayOfweek === 3;
+
+    // 해당 달이 총 몇주까지 있는지
+    const lastWeekNo = Math.ceil((firstDayOfWeek - 1 + lastDay) / 7);
+
+    // 날짜 기준으로 몇주차 인지
+    let weekNo = Math.ceil((firstDayOfWeek - 1 + date) / 7);
+    let flag;
+    // 인풋한 날짜가 첫 주에 있고 첫 날이 월, 화, 수로 시작한다면 'prev'(전달 마지막 주)
+    if (weekNo === 1 && firstWeekCheck) flag = 'prev';
+    // 인풋한 날짜가 마지막 주에 있고 마지막 날이 월, 화, 수로 끝난다면 'next'(다음달 첫 주)
+    else if (weekNo === lastWeekNo && lastWeekCheck) flag = 'next';
+    // 인풋한 날짜의 첫 주는 아니지만 첫날이 월, 화 수로 시작하면 -1;
+    else if (firstWeekCheck) weekNo = weekNo - 1;
+
+    return { weekNo, flag };
+  };
+
+  // 목요일 기준의 주차
+  let { weekNo, flag } = weekNumberByThurFnc(inputDate);
+
+  // 이전달의 마지막 주차일 떄
+  if (flag === 'prev') {
+    // 이전 달의 마지막날
+    const afterDate = new Date(year, month - 1, 0);
+    year = month === 1 ? year - 1 : year;
+    month = month === 1 ? 12 : month - 1;
+    const { weekNo } = weekNumberByThurFnc(afterDate);
+  }
+  // 다음달의 첫 주차일 때
+  if (flag === 'next') {
+    year = month === 12 ? year + 1 : year;
+    month = month === 12 ? 1 : month + 1;
+    weekNo = 1;
+  }
+
+  return { year, month, weekNo };
+}
+export default getWeekNumberByMonth;
+
+// https://falsy.me/javascript-%EC%9E%85%EB%A0%A5%ED%95%9C-%EB%82%A0%EC%A7%9C%EC%9D%98-%ED%95%B4%EB%8B%B9-%EB%8B%AC-%EA%B8%B0%EC%A4%80-%EC%A3%BC%EC%B0%A8-%EA%B5%AC%ED%95%98%EA%B8%B0/
+// ts로 수정


### PR DESCRIPTION
## 📝 PR Summary

주차계산 로직, 바텀시트 영역 외 터치 커스텀훅
![스크린샷 2022-08-01 오전 1 53 26](https://user-images.githubusercontent.com/55226431/182037000-52208752-3414-458a-8326-f7002d68df0d.png)

#### 🌲 Working Branch

refactor/bottomsheet-hooks

#### 🌲 TODOs

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->
모바일에서 바텀시트 오버레이 뒤 버튼 터치되는 오류 아직 못잡음...

### Related Issues

<!-- 예시) * resolves #71 -->
#106 
<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
